### PR TITLE
Bumped version number, moved permissionSets

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,47 @@
         "alt": "ERM: Comparison App for Stripes",
         "title": "ERMComparison"
       }
+    ],
+    "permissionSets": [
+      {
+        "permissionName": "module.erm-comparisons.enabled",
+        "displayName": "UI: ui-erm-comparisons module is enabled"
+      },
+      {
+        "permissionName": "ui-erm-comparisons.jobs.view",
+        "displayName": "ERM comparisons: View jobs",
+        "visible": true,
+        "subPermissions": [
+          "module.erm-comparisons.enabled",
+          "erm.jobs.view",
+          "erm.refdata.view"
+        ]
+      },
+      {
+        "permissionName": "ui-erm-comparisons.jobs.edit",
+        "displayName": "ERM Comparisons: Create jobs",
+        "visible": true,
+        "subPermissions": [
+          "ui-erm-comparisons.jobs.view",
+          "erm.jobs.edit"
+        ]
+      },
+      {
+        "permissionName": "ui-erm-comparisons.jobs.delete",
+        "displayName": "ERM Comparisons: Delete jobs",
+        "visible": true,
+        "subPermissions": [
+          "ui-erm-comparisons.jobs.view",
+          "erm.jobs.item.delete"
+        ]
+      },
+      {
+        "permissionName": "settings.erm-comparisons.enabled",
+        "displayName": "Settings (ERM comparisons): display list of settings pages",
+        "subPermissions": [
+          "settings.enabled"
+        ]
+      }
     ]
   },
   "devDependencies": {
@@ -84,46 +125,5 @@
     "react-redux": "*",
     "react-router-dom": "^5.2.0",
     "redux": "*"
-  },
-  "permissionSets": [
-    {
-      "permissionName": "module.erm-comparisons.enabled",
-      "displayName": "UI: ui-erm-comparisons module is enabled"
-    },
-    {
-      "permissionName": "ui-erm-comparisons.jobs.view",
-      "displayName": "ERM comparisons: View jobs",
-      "visible": true,
-      "subPermissions": [
-        "module.erm-comparisons.enabled",
-        "erm.jobs.view",
-        "erm.refdata.view"
-      ]
-    },
-    {
-      "permissionName": "ui-erm-comparisons.jobs.edit",
-      "displayName": "ERM Comparisons: Create jobs",
-      "visible": true,
-      "subPermissions": [
-        "ui-erm-comparisons.jobs.view",
-        "erm.jobs.edit"
-      ]
-    },
-    {
-      "permissionName": "ui-erm-comparisons.jobs.delete",
-      "displayName": "ERM Comparisons: Delete jobs",
-      "visible": true,
-      "subPermissions": [
-        "ui-erm-comparisons.jobs.view",
-        "erm.jobs.item.delete"
-      ]
-    },
-    {
-      "permissionName": "settings.erm-comparisons.enabled",
-      "displayName": "Settings (ERM comparisons): display list of settings pages",
-      "subPermissions": [
-        "settings.enabled"
-      ]
-    }
-  ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/erm-comparisons",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "ERM app for comparison of Agreement and Package objects",
   "main": "src/index.js",
   "repository": "folio-org/ui-erm-comparisons",

--- a/src/routes/ComparisonCreateRoute.js
+++ b/src/routes/ComparisonCreateRoute.js
@@ -165,7 +165,7 @@ class ComparisonCreateRoute extends React.Component {
         const name = response?.name ?? '';
 
         history.push(`/comparisons-erm/${comparisonId}${location.search}`);
-        this.context.sendCallout({ message: <SafeHTMLMessage id="ui-erm-comparison.comparison.created.success" values={{ name }} /> });
+        this.context.sendCallout({ message: <SafeHTMLMessage id="ui-erm-comparisons.comparison.created.success" values={{ name }} /> });
       });
   }
 

--- a/translations/ui-erm-comparisons/en.json
+++ b/translations/ui-erm-comparisons/en.json
@@ -41,6 +41,8 @@
   "prop.status": "Running status",
   "prop.viewReport": "View comparison report",
   "prop.comparisonPoints": "Comparison points",
+  "prop.comparisonPointOne": "Comparison point 1",
+  "prop.comparisonPointTwo": "Comparison point 2",
   "prop.noComparisonPoints": "No comparison points",
 
   "source": "Source",


### PR DESCRIPTION
Early in development the name of this repo and app changed from singular to plural, but mistakenly the version number was not bumped. In addition, the initial permission sets were in the incorrect position in the package.json. Those have both been rectified, as well as a couple of translation omissions/mistakes ironed out.