### PR TITLE
ERM-1018, ERM-1022: ERM-1039 Comparisons Tweaks

### DIFF
--- a/src/components/ComparisonSections/ComparisonInfo.js
+++ b/src/components/ComparisonSections/ComparisonInfo.js
@@ -32,7 +32,7 @@ export default class ComparisonInfo extends React.Component {
           </Col>
         </Row>
         <Row>
-          <Col xs={4}>
+          <Col xs={3}>
             <KeyValue label={<FormattedMessage id="ui-erm-comparisons.prop.runningStatus" />}>
               <div data-test-comparison-status>
                 {comparison?.status?.label ?? <NoValue />}
@@ -41,61 +41,60 @@ export default class ComparisonInfo extends React.Component {
           </Col>
           {
             isComparisonNotQueued && (
-              <Col xs={4}>
-                <KeyValue label={<FormattedMessage id="ui-erm-comparisons.prop.outcome" />}>
-                  <div data-test-comparison-result>
-                    {comparison?.result?.label ?? <NoValue />}
-                  </div>
-                </KeyValue>
-              </Col>
-            )
-          }
-          {
-            isComparisonNotQueued && (
-              <Col xs={4}>
-                <KeyValue label={<FormattedMessage id="ui-erm-comparisons.prop.errors" />}>
-                  <div data-test-comparison-errors>
-                    {comparison.errorLog ? comparison.errorLog?.length : '0'}
-                  </div>
-                </KeyValue>
-              </Col>
-            )
-          }
-        </Row>
-        <Row>
-          {
-            isComparisonNotQueued && (
-              <Col xs={4}>
-                <KeyValue label={<FormattedMessage id="ui-erm-comparisons.prop.started" />}>
-                  <div data-test-comparison-started>
-                    {comparison.started ? <FormattedDateTime date={comparison.started} /> : <NoValue />}
-                  </div>
-                </KeyValue>
-              </Col>
-            )
-          }
-          {
-            isComparisonNotQueued && (
-              <Col xs={4}>
-                <KeyValue label={<FormattedMessage id="ui-erm-comparisons.prop.ended" />}>
-                  <div data-test-comparison-ended>
-                    {comparison.ended ? <FormattedDateTime date={comparison.ended} /> : <NoValue />}
-                  </div>
-                </KeyValue>
-              </Col>
+              <>
+                <Col xs={3}>
+                  <KeyValue label={<FormattedMessage id="ui-erm-comparisons.prop.outcome" />}>
+                    <div data-test-comparison-result>
+                      {comparison?.result?.label ?? <NoValue />}
+                    </div>
+                  </KeyValue>
+                </Col>
+                <Col xs={3}>
+                  <KeyValue label={<FormattedMessage id="ui-erm-comparisons.prop.started" />}>
+                    <div data-test-comparison-started>
+                      {comparison.started ? <FormattedDateTime date={comparison.started} /> : <NoValue />}
+                    </div>
+                  </KeyValue>
+                </Col>
+                <Col xs={3}>
+                  <KeyValue label={<FormattedMessage id="ui-erm-comparisons.prop.ended" />}>
+                    <div data-test-comparison-ended>
+                      {comparison.ended ? <FormattedDateTime date={comparison.ended} /> : <NoValue />}
+                    </div>
+                  </KeyValue>
+                </Col>
+              </>
             )
           }
         </Row>
-        <Row>
-          <Button
-            buttonStyle="primary mega"
-            data-test-comparison-report-view
-            marginBottom0
-            onClick={onViewReport}
-          >
-            <FormattedMessage id="ui-erm-comparisons.prop.viewReport" />
-          </Button>
-        </Row>
+        {
+          isComparisonNotQueued && (
+            <>
+              <Row>
+                <Col xs={3}>
+                  <KeyValue label={<FormattedMessage id="ui-erm-comparisons.prop.errors" />}>
+                    <div data-test-comparison-errors>
+                      {comparison.errorLog ? comparison.errorLog?.length : '0'}
+                    </div>
+                  </KeyValue>
+                </Col>
+              </Row>
+              <Row>
+                <Col xs={12}>
+                  <Button
+                    buttonStyle="primary"
+                    data-test-comparison-report-view
+                    fullWidth
+                    marginBottom0
+                    onClick={onViewReport}
+                  >
+                    <FormattedMessage id="ui-erm-comparisons.prop.viewReport" />
+                  </Button>
+                </Col>
+              </Row>
+            </>
+          )
+        }
       </div>
     );
   }

--- a/src/components/ComparisonSections/ComparisonInfo.js
+++ b/src/components/ComparisonSections/ComparisonInfo.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {
   Button,
   Col,
+  Headline,
   KeyValue,
   NoValue,
   Row,
@@ -23,12 +24,14 @@ export default class ComparisonInfo extends React.Component {
     return (
       <div>
         <Row>
-          <Col xs={9}>
-            <KeyValue label={<FormattedMessage id="ui-erm-comparisons.prop.comparisonName" />}>
-              <div data-test-comparison-name>
-                <strong>{comparison.name}</strong>
-              </div>
-            </KeyValue>
+          <Col xs={12}>
+            <Headline
+              data-test-comparison-name
+              size="xx-large"
+              tag="h2"
+            >
+              {comparison.name}
+            </Headline>
           </Col>
         </Row>
         <Row>

--- a/src/components/views/ComparisonView.js
+++ b/src/components/views/ComparisonView.js
@@ -13,7 +13,7 @@ import {
   Row,
   Spinner
 } from '@folio/stripes/components';
-import { IfPermission, TitleManager } from '@folio/stripes/core';
+import { AppIcon, IfPermission, TitleManager } from '@folio/stripes/core';
 
 import { ComparisonInfo, ComparisonPoints } from '../ComparisonSections';
 
@@ -110,6 +110,7 @@ export default class ComparisonView extends React.Component {
     return (
       <Pane
         actionMenu={this.getActionMenu}
+        appIcon={<AppIcon app="erm-comparisons" />}
         data-test-comparison-details
         defaultWidth="45%"
         dismissible

--- a/src/components/views/ComparisonView.js
+++ b/src/components/views/ComparisonView.js
@@ -123,30 +123,32 @@ export default class ComparisonView extends React.Component {
       >
         <TitleManager data-test-title-name record={comparison.name}>
           <ComparisonInfo {...{ comparison, isComparisonNotQueued, onViewReport }} />
-          {
-            isComparisonNotQueued ? (
-              <AccordionSet>
-                <Row end="xs">
-                  <Col xs>
-                    <ExpandAllButton
-                      accordionStatus={this.state.sections}
-                      id="clickable-expand-all"
-                      onToggle={this.handleAllSectionsToggle}
-                    />
-                  </Col>
-                </Row>
-                <ComparisonPoints {...this.getSectionProps('comparisonPoints')} />
-                <Logs
-                  type="error"
-                  {...this.getSectionProps('errorLogs')}
+          <AccordionSet>
+            <Row end="xs">
+              <Col xs>
+                <ExpandAllButton
+                  accordionStatus={this.state.sections}
+                  id="clickable-expand-all"
+                  onToggle={this.handleAllSectionsToggle}
                 />
-                <Logs
-                  type="info"
-                  {...this.getSectionProps('infoLogs')}
-                />
-              </AccordionSet>
-            ) : null
-          }
+              </Col>
+            </Row>
+            <ComparisonPoints {...this.getSectionProps('comparisonPoints')} />
+            {
+              isComparisonNotQueued ? (
+                <>
+                  <Logs
+                    type="error"
+                    {...this.getSectionProps('errorLogs')}
+                  />
+                  <Logs
+                    type="info"
+                    {...this.getSectionProps('infoLogs')}
+                  />
+                </>
+              ) : null
+            }
+          </AccordionSet>
         </TitleManager>
       </Pane>
     );

--- a/src/components/views/Comparisons.js
+++ b/src/components/views/Comparisons.js
@@ -191,7 +191,7 @@ export default class Comparisons extends React.Component {
     return (
       <div ref={contentRef} data-test-ermcomparisons>
         <SearchAndSortQuery
-          initialFilterState={{ status: ['Queued', 'In progress'] }}
+          initialFilterState={{ }}
           initialSearchState={{ query: '' }}
           initialSortState={{ sort: '-started' }}
           queryGetter={queryGetter}

--- a/src/components/views/Comparisons.js
+++ b/src/components/views/Comparisons.js
@@ -67,9 +67,22 @@ export default class Comparisons extends React.Component {
   }
 
   formatter = {
+    comparisonName: ({ name }) => {
+      return (
+        <AppIcon
+          app="erm-comparisons"
+          iconAlignment="baseline"
+          iconKey="app"
+          size="small"
+        >
+          <div style={{ overflowWrap: 'break-word', width: 460 }}>
+            {name}
+          </div>
+        </AppIcon>
+      );
+    },
     ended: ({ ended }) => (ended ? <FormattedDateTime date={ended} /> : <NoValue />),
     errors: ({ errorLogCount }) => errorLogCount,
-    comparisonName: ({ name }) => name,
     runningStatus: ({ status }) => status && status.label,
     result: ({ result }) => result && result.label,
     started: ({ started }) => (started ? <FormattedDateTime date={started} /> : <NoValue />),

--- a/test/bigtest/tests/comparison-info-test.js
+++ b/test/bigtest/tests/comparison-info-test.js
@@ -142,8 +142,8 @@ describe('Comparison info', () => {
         expect(interactor.isComparisonEndedPresent).to.be.false;
       });
 
-      it('renders \'view report\' button', () => {
-        expect(interactor.isViewReportButtonPresent).to.be.true;
+      it('does not render \'view report\' button', () => {
+        expect(interactor.isViewReportButtonPresent).to.be.false;
       });
     });
   });

--- a/translations/ui-erm-comparisons/en.json
+++ b/translations/ui-erm-comparisons/en.json
@@ -38,7 +38,7 @@
   "prop.ended": "Ended",
   "prop.errors": "Errors",
   "prop.filename": "Filename",
-  "prop.comparisonName": "Comparison name",
+  "prop.comparisonName": "Name",
   "prop.noOfErrors": "No. of errors",
   "prop.outcome": "Import outcome",
   "prop.result": "Result",

--- a/translations/ui-erm-comparisons/en.json
+++ b/translations/ui-erm-comparisons/en.json
@@ -41,7 +41,7 @@
   "prop.filename": "Filename",
   "prop.comparisonName": "Name",
   "prop.noOfErrors": "No. of errors",
-  "prop.outcome": "Import outcome",
+  "prop.outcome": "Outcome",
   "prop.result": "Result",
   "prop.runningStatus": "Running status",
   "prop.started": "Started",

--- a/translations/ui-erm-comparisons/en_US.json
+++ b/translations/ui-erm-comparisons/en_US.json
@@ -28,7 +28,7 @@
     "prop.filename": "Filename",
     "prop.comparisonName": "Name",
     "prop.noOfErrors": "No. of errors",
-    "prop.outcome": "Import outcome",
+    "prop.outcome": "Outcome",
     "prop.result": "Result",
     "prop.runningStatus": "Running status",
     "prop.started": "Started",

--- a/translations/ui-erm-comparisons/en_US.json
+++ b/translations/ui-erm-comparisons/en_US.json
@@ -26,7 +26,7 @@
     "prop.ended": "Ended",
     "prop.errors": "Errors",
     "prop.filename": "Filename",
-    "prop.comparisonName": "Comparison name",
+    "prop.comparisonName": "Name",
     "prop.noOfErrors": "No. of errors",
     "prop.outcome": "Import outcome",
     "prop.result": "Result",


### PR DESCRIPTION
**S&S Screen:**

- Removed default filter
- Renamed 'name' column
- Added comparison icon

**Comparison View Screen**

- Formatting changes to pane, moved information around, changed button style
- Icon in header, title formatted consistently with other apps
- Changes to what's displayed while running/queued (View report button, all non-status info and logs are hidden while queued--running status and comparison points are displayed)