### PR TITLE
Fixes bug when Dates are not saved as entered when tenant timezone is…

### DIFF
--- a/src/components/ComparisonPointFieldArray/ComparisonPointFieldArray.js
+++ b/src/components/ComparisonPointFieldArray/ComparisonPointFieldArray.js
@@ -8,8 +8,6 @@ import { Button, Col, Datepicker, Row } from '@folio/stripes/components';
 import { EditCard, requiredValidator, withKiwtFieldArray } from '@folio/stripes-erm-components';
 import ComparisonPointField from './ComparisonPointField';
 
-import { parseDateOnlyString } from '../utilities';
-
 class ComparisonPointFieldArray extends React.Component {
   static propTypes = {
     addButtonId: PropTypes.string,
@@ -110,8 +108,8 @@ class ComparisonPointFieldArray extends React.Component {
                 index={index}
                 label={<FormattedMessage id="ui-erm-comparisons.newComparison.onDate" />}
                 name={`${name}[${index}].onDate`}
-                parser={parseDateOnlyString}
                 required
+                timeZone="UTC"
                 usePortal
                 validate={requiredValidator}
               />

--- a/src/components/utilities/index.js
+++ b/src/components/utilities/index.js
@@ -3,5 +3,3 @@ export {
   getResourceColumnHeader,
   getResourceOccurrence
 } from './comparisonReportUtils';
-
-export { default as parseDateOnlyString } from './parseDateOnlyString';

--- a/src/components/utilities/parseDateOnlyString.js
+++ b/src/components/utilities/parseDateOnlyString.js
@@ -1,7 +1,0 @@
-import moment from 'moment';
-
-const parseDateOnlyString = (value, _timeZone, dateFormat) => {
-  return (!value || value === '') ? value : moment(value).format(dateFormat);
-};
-
-export default parseDateOnlyString;


### PR DESCRIPTION
… ahead of UTC, refs ERM-1202

See [comment](https://github.com/folio-org/ui-agreements/pull/658#issue-514364687)