### PR TITLE
ERM-1895 upgrade react-intl-safe-html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-erm-comparisons
 
+## 4.1.0 IN PROGRESS
+
+* Upgrade `@folio/react-intl-safe-html` for compatibility with `@folio/stripes` `v7`. ERM-1895.
+
 ## 4.0.0 2021-10-07
 * Upgrade to stripes v7
 * Display keyboard shortcuts modal. ERM-1737

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "sinon": "^9.0.2"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^2.0.0",
+    "@folio/react-intl-safe-html": "^3.1.0",
     "@folio/stripes-erm-components": "^6.0.0",
     "compose-function": "^3.0.3",
     "final-form": "^4.18.5",


### PR DESCRIPTION
Upgrade `@folio/react-intl-safe-html` for compatibility with
`@folio/stripes` `v7` (react 17, react-intl 5).

@aditya-matukumalli, @CalamityC: I don't have write privs in this repo to add PR reviewers. If this looks good to you, please merge it. Thanks!

[ERM-1895](https://issues.folio.org/browse/ERM-1895), [STRIPES-769](https://issues.folio.org/browse/STRIPES-769)