### PR TITLE
ERM-2373: @folio/stripes-testing is incorrectly listed as a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,6 @@
     "sinon": "^9.0.2"
   },
   "dependencies": {
-    "@folio/stripes-testing": "^4.2.0",
     "@k-int/stripes-kint-components": "^2.5.0",
     "compose-function": "^3.0.3",
     "final-form": "^4.18.5",


### PR DESCRIPTION
build: stripes-testing

Added stripes-testing as a devDep and removed it as a direct dep

ERM-2373