### PR TITLE
chore: Stripes-erm-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@folio/handler-stripes-registry": "^1.3.0",
     "@folio/stripes": "^7.3.1",
     "@folio/stripes-cli": "^2.6.1",
-    "@folio/stripes-erm-components": "^7.0.1",
+    "@folio/stripes-erm-components": "^8.0.0",
     "@folio/stripes-erm-testing": "^1.0.0",
     "@folio/stripes-testing": "^4.2.0",
     "@formatjs/cli": "^4.2.31",
@@ -172,7 +172,7 @@
   "peerDependencies": {
     "@folio/handler-stripes-registry": "^1.3.0",
     "@folio/stripes": "^7.3.1",
-    "@folio/stripes-erm-components": "^7.0.1",
+    "@folio/stripes-erm-components": "^8.0.0",
     "moment": "^2.22.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
Bumped major version of stripes-erm-components to ^8.0.0, reflecting removal of testing stuff for Orchid

ERM-2456