### PR TITLE
ERM-2907 Quarantine global CSS selector in ERM-Comparisons

### DIFF
--- a/src/components/views/ComparisonReportList/ComparisonReportList.css
+++ b/src/components/views/ComparisonReportList/ComparisonReportList.css
@@ -14,8 +14,8 @@
   }
 }
 
-div[role="gridcell"] {
-  border-top: 1px solid var(--color-border-p2);
+.borderCell{
+   border-top: 1px solid var(--color-border-p2);
 }
 
 /* overlap column coloring classes */

--- a/src/components/views/ComparisonReportList/ComparisonReportList.js
+++ b/src/components/views/ComparisonReportList/ComparisonReportList.js
@@ -315,7 +315,7 @@ const ComparisonReportList = (
                                 return (
                                   <div
                                     key={`row-${rowIndex}`}
-                                    className={rowClass}
+                                    className={`${rowClass} ${css.borderCell}`}
                                     data-test-coverage-mcl-row
                                     {...rowProps}
                                     // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex

--- a/src/components/views/ComparisonReportList/ComparisonReportList.js
+++ b/src/components/views/ComparisonReportList/ComparisonReportList.js
@@ -199,11 +199,11 @@ const ComparisonReportList = (
       getCellClass={(defaultClass, rowData, column) => {
         const { overlap } = rowData;
         if (column === 'overlap') {
-          return `${defaultClass} ${css[overlap]}`;
+          return `${defaultClass} ${css[overlap]} ${css.borderCell}`;
         } else if (column === 'title') {
-          return `${defaultClass} ${css.titleCell}`;
+          return `${defaultClass} ${css.titleCell} ${css.borderCell}`;
         }
-        return defaultClass;
+        return `${defaultClass} ${css.borderCell}`;
       }}
       getHeaderCellClass={(header) => {
         return ['coverage', 'resourceA', 'resourceB', 'overlap'].includes(header) ? css[header] : undefined;
@@ -237,7 +237,7 @@ const ComparisonReportList = (
               cells[0]
             }
             {
-              <div aria-colspan="4" className={css.nestedMcl}>
+              <div aria-colspan="4" className={`${css.nestedMcl} ${css.borderCell}`}>
                 <MultiColumnList
                   columnWidths={{
                     availableVia: 250,
@@ -285,6 +285,7 @@ const ComparisonReportList = (
                       >
                         {cells[0]}
                         {
+                          // no css.borderCell needed here, it would double the cell border
                           <div aria-colspan="3" className={css.nestedMcl}>
                             <MultiColumnList
                               columnWidths={{


### PR DESCRIPTION
* replace global gridcell selector with a local css class
* use that css.class in getCellClass and other style statements