### PR TITLE
lock to aria-query v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,5 +171,8 @@
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.1",
     "react-router-dom": "^5.2.0"
+  },
+  "resolutions": {
+    "aria-query": "^4"
   }
 }


### PR DESCRIPTION
Avoid `aria-query` `v5`, transiently pulled in via `@testing-library/react`, due to https://github.com/A11yance/aria-query/issues/511