### PR TITLE
ERM-3123 Remove color() function in comparison report CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-erm-comparisons
 
 ## 6.1.0 In progress
+* ERM-3123 Remove redundant CSS `color()` usage.
 
 ## 6.0.0 2023-10-13
 * ERM-3045 Swap Logs component to prev-next pagination

--- a/src/components/views/ComparisonReportList/ComparisonReportList.css
+++ b/src/components/views/ComparisonReportList/ComparisonReportList.css
@@ -20,7 +20,7 @@
 
 /* overlap column coloring classes */
 .none {
-  background-color: color(var(--error, #900));
+  background-color: var(--error, #900);
   color: var(--bg);
   border-bottom: 1px solid var(--bg);
 }
@@ -32,7 +32,7 @@
 }
 
 .full {
-  background-color: color(var(--success, #060));
+  background-color: var(--success, #060);
   color: var(--bg);
   border-bottom: 1px solid var(--bg);
 }


### PR DESCRIPTION
https://issues.folio.org/browse/ERM-3123

Minor CSS factors are required for upcoming changes to our postCSS stack. The spec changed for the CSS `color()` function - it's now used to trasition colors between color spaces, rather than blend or any other purpose that our outdated postcss plugin -`postcss-color-function` would have us implement. In order for us to remove this plugin, UI modules should refactor styles to perform blending and adjustment in standards-compatible ways. You can see https://issues.folio.org/browse/STCOM-1164 for alternatives for reference. In this PR, the case was only to remove unnecessary usage of the `color()` function.