### PR TITLE
ERM-3610: Stripes v10 dependencies update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/erm-comparisons",
-  "version": "7.2.0",
+  "version": "8.0.0",
   "description": "ERM app for comparison of Agreement and Package objects",
   "main": "src/index.js",
   "repository": "folio-org/ui-erm-comparisons",
@@ -92,21 +92,20 @@
   "devDependencies": {
     "@babel/core": "^7.18.9",
     "@babel/eslint-parser": "^7.15.0",
-    "@folio/eslint-config-stripes": "^7.1.0",
-    "@folio/handler-stripes-registry": "^2.3.0",
-    "@folio/jest-config-stripes": "^2.0.0",
-    "@folio/stripes": "^9.2.0",
-    "@folio/stripes-cli": "^3.2.0",
-    "@folio/stripes-erm-components": "^9.2.0",
-    "@folio/stripes-erm-testing": "^2.2.1",
-    "@formatjs/cli": "^6.1.3",
+    "@folio/eslint-config-stripes": "^8.0.0",
+    "@folio/handler-stripes-registry": "^3.0.0",
+    "@folio/jest-config-stripes": "^3.0.0",
+    "@folio/stripes": "^10.0.0",
+    "@folio/stripes-cli": "^4.0.0",
+    "@folio/stripes-erm-components": "^10.0.0",
+    "@folio/stripes-erm-testing": "^3.0.0",
+    "@formatjs/cli": "^6.6.0",
     "eslint": "^7.32.0",
     "graphql": "^16.0.0",
     "inflected": "^2.0.4",
-    "moment": "^2.29.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-query": "^3.6.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
@@ -116,9 +115,10 @@
     "rxjs": "^6.6.3"
   },
   "dependencies": {
-    "@k-int/stripes-kint-components": "^5.8.3",
+    "@k-int/stripes-kint-components": "^5.11.0",
     "@rehooks/local-storage": "^2.4.5",
     "compose-function": "^3.0.3",
+    "dayjs": "^1.11.13",
     "final-form": "^4.18.5",
     "final-form-arrays": "^3.0.1",
     "lodash": "^4.17.11",
@@ -128,13 +128,12 @@
     "react-final-form-arrays": "^3.1.1"
   },
   "peerDependencies": {
-    "@folio/handler-stripes-registry": "^2.3.0",
-    "@folio/stripes": "^9.2.0",
-    "@folio/stripes-erm-components": "^9.2.0",
-    "moment": "^2.22.2",
+    "@folio/handler-stripes-registry": "^3.0.0",
+    "@folio/stripes": "^10.0.0",
+    "@folio/stripes-erm-components": "^10.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0"
   }
 }

--- a/src/components/ComparisonPointFieldArray/ComparisonPointFieldArray.js
+++ b/src/components/ComparisonPointFieldArray/ComparisonPointFieldArray.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'react-final-form';
@@ -74,7 +74,7 @@ const ComparisonPointFieldArray = ({
             <Col xs={3}>
               <Field
                 component={Datepicker}
-                defaultValue={moment.utc().startOf('day').toISOString()}
+                defaultValue={dayjs.utc().format('MM/DD/YYYY')}
                 id={`data-test-field-date-${comparisonType}`}
                 index={index}
                 label={<FormattedMessage id="ui-erm-comparisons.newComparison.onDate" />}

--- a/src/routes/ComparisonsRoute/ComparisonsRoute.test.js
+++ b/src/routes/ComparisonsRoute/ComparisonsRoute.test.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { cleanup } from '@folio/jest-config-stripes/testing-library/react';
+
 import { renderWithIntl } from '@folio/stripes-erm-testing';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -42,6 +44,9 @@ describe('ComparisonsRoute', () => {
 
     describe('re-rendering the route', () => { // makes sure that we hit the componentDidUpdate block
       beforeEach(() => {
+        // Using this to clean up the render component prior to rerender
+        cleanup();
+
         renderWithIntl(
           <MemoryRouter>
             <ComparisonsRoute {...data} />


### PR DESCRIPTION
BREAKING Updated all stripes-* dependencies for the stripes v10 upgrade along with react-intl and formatjs/cli

Bumped version to 8.0.0

ERM-3610